### PR TITLE
Restore spaces in single-line throwing lambda

### DIFF
--- a/IntelliJIdea2019/Airlift.xml
+++ b/IntelliJIdea2019/Airlift.xml
@@ -154,6 +154,7 @@
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="SPACE_WITHIN_BRACES" value="true" />
     <option name="FIELD_ANNOTATION_WRAP" value="0" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     <arrangement>


### PR DESCRIPTION
IntelliJ 2021.2 no longer adds spaces within `{ throw ...; }` lambda
definition. This restores the behavior that IntelliJ 2020 and older used
to have by default.