### PR TITLE
Revert "Preserve space within single-line code blocks"

### DIFF
--- a/IntelliJIdea2019/Airlift.xml
+++ b/IntelliJIdea2019/Airlift.xml
@@ -36,7 +36,6 @@
   <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
   <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
   <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
-  <option name="SPACE_WITHIN_BRACES" value="true" />
   <option name="CALL_PARAMETERS_WRAP" value="5" />
   <option name="EXTENDS_LIST_WRAP" value="1" />
   <option name="THROWS_LIST_WRAP" value="1" />


### PR DESCRIPTION
This reverts commit 3fbde21e2761e7d985c55bb3ec53b5da31eac459. The change has unforeseen side-effects that cause violate airbase checkstyle rules.

Reverts https://github.com/airlift/codestyle/pull/15